### PR TITLE
Feat chat history

### DIFF
--- a/backend/app/migrations/versions/7c2a4b5bf1a1_add_chat_messages.py
+++ b/backend/app/migrations/versions/7c2a4b5bf1a1_add_chat_messages.py
@@ -1,0 +1,43 @@
+"""add chat messages
+
+Revision ID: 7c2a4b5bf1a1
+Revises: 55a37c1d5c06
+Create Date: 2025-08-25 12:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7c2a4b5bf1a1"
+down_revision: Union[str, None] = "55a37c1d5c06"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_messages",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.Float(), nullable=False),
+        sa.Column("role", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("content", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_chat_messages_created_at"), "chat_messages", ["created_at"], unique=False)
+    op.create_index(op.f("ix_chat_messages_role"), "chat_messages", ["role"], unique=False)
+    op.create_index(op.f("ix_chat_messages_user_id"), "chat_messages", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_chat_messages_user_id"), table_name="chat_messages")
+    op.drop_index(op.f("ix_chat_messages_role"), table_name="chat_messages")
+    op.drop_index(op.f("ix_chat_messages_created_at"), table_name="chat_messages")
+    op.drop_table("chat_messages")
+

--- a/backend/app/models/chat.py
+++ b/backend/app/models/chat.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel
 
 
@@ -7,3 +9,19 @@ class ChatRequestModel(BaseModel):
 
 class ChatResponseModel(BaseModel):
     response: str
+
+
+class ChatMessageModel(BaseModel):
+    id: int
+    role: str
+    content: str
+    created_at: float
+
+    @property
+    def created_at_dt(self) -> datetime:
+        return datetime.fromtimestamp(self.created_at)
+
+
+class ChatHistoryResponseModel(BaseModel):
+    total: int
+    messages: list[ChatMessageModel]

--- a/backend/app/repositories/chat_history.py
+++ b/backend/app/repositories/chat_history.py
@@ -1,0 +1,33 @@
+from app.schema import ChatMessage, User
+from sqlmodel import Session, select
+
+
+def add_message(session: Session, user: User, role: str, content: str) -> ChatMessage:
+    """チャットメッセージを保存します。"""
+    message = ChatMessage(user_id=user.id, role=role, content=content)
+    session.add(message)
+    session.commit()
+    session.refresh(message)
+    return message
+
+
+def get_last_messages(session: Session, user: User, limit: int) -> list[ChatMessage]:
+    """直近のメッセージを新しい順で limit 件取得し、古い順に並べ替えて返します。"""
+    stmt = (
+        select(ChatMessage)
+        .where(ChatMessage.user_id == user.id)
+        .order_by(ChatMessage.created_at.desc())
+        .limit(limit)
+    )
+    rows = session.exec(stmt).all()
+    return list(reversed(rows))
+
+
+def clear_messages(session: Session, user: User) -> int:
+    """ユーザの全メッセージを削除して件数を返す。"""
+    stmt = select(ChatMessage).where(ChatMessage.user_id == user.id)
+    rows = session.exec(stmt).all()
+    for m in rows:
+        session.delete(m)
+    session.commit()
+    return len(rows)

--- a/backend/app/routers/api/chat.py
+++ b/backend/app/routers/api/chat.py
@@ -1,11 +1,50 @@
-from app.models.chat import ChatRequestModel, ChatResponseModel
+from app.database import get_session
+from app.models.chat import (
+    ChatHistoryResponseModel,
+    ChatMessageModel,
+    ChatRequestModel,
+    ChatResponseModel,
+)
+from app.repositories.chat_history import clear_messages, get_last_messages
+from app.schema import User
+from app.services.auth import auth_user
 from app.services.chat import send_chat
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Query, status
+from sqlmodel import Session
 
 router = APIRouter(prefix="/chat")
 
 
 @router.post("", response_model=ChatResponseModel)
-async def chat(data: ChatRequestModel):
-    response = await send_chat(data.prompt)
+async def chat(
+    data: ChatRequestModel,
+    user: User = Depends(auth_user),
+    session: Session = Depends(get_session),
+    limit: int | None = Query(None, description="履歴に含める最大件数"),
+):
+    response = await send_chat(data.prompt, user=user, session=session, limit=limit)
     return {"response": response}
+
+
+@router.get("/history", response_model=ChatHistoryResponseModel)
+def get_history(
+    limit: int = Query(30, ge=1, le=200, description="取得する履歴件数"),
+    user: User = Depends(auth_user),
+    session: Session = Depends(get_session),
+):
+    rows = get_last_messages(session, user, limit)
+    messages: list[ChatMessageModel] = [
+        ChatMessageModel(
+            id=m.id, role=m.role, content=m.content, created_at=m.created_at
+        )
+        for m in rows
+    ]
+    return {"total": len(messages), "messages": messages}
+
+
+@router.delete("/history", status_code=status.HTTP_204_NO_CONTENT)
+def clear_history(
+    user: User = Depends(auth_user), session: Session = Depends(get_session)
+):
+    clear_messages(session, user)
+    return

--- a/backend/app/schema.py
+++ b/backend/app/schema.py
@@ -34,4 +34,22 @@ class PasswordResetToken(SQLModel, table=True):
     user: User = Relationship(back_populates="password_reset_tokens")
 
 
+class ChatMessage(SQLModel, table=True):
+    """チャット履歴の1メッセージ（ユーザ/アシスタント両方）。"""
+
+    __tablename__ = "chat_messages"
+    __table_args__ = {"extend_existing": True}
+
+    id: int | None = Field(default=None, primary_key=True)
+    created_at: float = Field(
+        default_factory=lambda: datetime.now().timestamp(), index=True
+    )
+
+    role: str = Field(index=True)  # "user" | "assistant"
+    content: str
+
+    user_id: int = Field(foreign_key="users.id", index=True)
+    user: User | None = Relationship()
+
+
 metadata = SQLModel.metadata

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -1,16 +1,37 @@
+import os
+
+from app.repositories.chat_history import (
+    add_message,
+    get_last_messages,
+)
+from app.schema import User
 from app.utils.llm import generate_response
+from sqlmodel import Session
+
+DEFAULT_HISTORY_LIMIT = int(os.getenv("CHAT_HISTORY_LIMIT", "30"))
 
 
-async def send_chat(prompt: str) -> str:
-    messages = [
-        {
-            "role": "user",
-            "content": prompt,
-        }
+async def send_chat(
+    prompt: str, user: User, session: Session, limit: int | None = None
+) -> str:
+    """履歴を含めて LLM に投げ、ユーザ/アシスタント両方を保存。"""
+    ctx_limit = limit or DEFAULT_HISTORY_LIMIT
+
+    # 直近メッセージを取得（古い→新しい順）
+    history = get_last_messages(session, user, ctx_limit)
+
+    messages = [{"role": m.role, "content": m.content} for m in history] + [
+        {"role": "user", "content": prompt}
     ]
+
     try:
-        response = generate_response(messages=messages)
-        return response
+        response_text = generate_response(messages=messages)
     except Exception as e:
         print(f"Error during response generation: {e}")
         return "An error occurred while processing your request."
+
+    # 保存（ユーザの入力とアシスタントの応答）
+    add_message(session, user, role="user", content=prompt)
+    add_message(session, user, role="assistant", content=response_text)
+
+    return response_text

--- a/frontend/app/api/chat/history/route.ts
+++ b/frontend/app/api/chat/history/route.ts
@@ -1,0 +1,31 @@
+import { apiDelete, apiGet } from "@/utils/api";
+import { NextRequest, NextResponse } from "next/server";
+
+// GET /api/chat/history -> バックエンドの /api/chat/history を転送
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const limit = searchParams.get("limit") ?? undefined;
+  const query = limit ? `?limit=${encodeURIComponent(limit)}` : "";
+
+  const { data, error } = await apiGet(`/chat/history${query}`);
+  if (error) {
+    return NextResponse.json(
+      { message: error.message },
+      { status: error.status || 500 }
+    );
+  }
+  return NextResponse.json(data);
+}
+
+// DELETE /api/chat/history -> バックエンドの /api/chat/history を転送
+export async function DELETE() {
+  const { error } = await apiDelete("/chat/history");
+  if (error) {
+    return NextResponse.json(
+      { message: error.message },
+      { status: error.status || 500 }
+    );
+  }
+  return new NextResponse(null, { status: 204 });
+}
+


### PR DESCRIPTION
This pull request adds persistent chat history support to both the backend and frontend, allowing users to view, restore, and reset their chat history with the AI assistant. It introduces a new database table for chat messages, backend APIs for history management, and frontend integration for displaying and controlling chat history.

**Backend: Chat History Persistence & API**

* Added a new `chat_messages` table via Alembic migration to store chat messages with user association, role, content, and timestamps. [[1]](diffhunk://#diff-f96c845960b8adc621621b45b2fb4d86d4f8d737502eabc7763df0c8aaefe5f3R1-R43) [[2]](diffhunk://#diff-a3b14214ea08adcb91b4116375c2eefd1227200f241e93a7bb254a8b7c893d1aR37-R54)
* Implemented repository functions for adding, retrieving, and clearing chat messages (`add_message`, `get_last_messages`, `clear_messages` in `chat_history.py`).
* Extended chat API endpoints to support history retrieval (`GET /chat/history`) and clearing (`DELETE /chat/history`), and updated the chat endpoint to save both user and assistant messages. [[1]](diffhunk://#diff-5c6c35b39330b7eb0bcb7fadf2a755e9db97901e2743670f7e899586f71a87ebL1-R50) [[2]](diffhunk://#diff-7533e4ec8ccfc6f1e9d2a59fdec15bfbd7b707d8c9f3ebd749d98ac663bfa025R1-R37)
* Added new Pydantic models for chat message and history response serialization. [[1]](diffhunk://#diff-c94773c08d5cd254e0bba70924234e0f7b7a360290836c4f46c1d017a4843d1aR1-R2) [[2]](diffhunk://#diff-c94773c08d5cd254e0bba70924234e0f7b7a360290836c4f46c1d017a4843d1aR12-R27)

**Frontend: Chat History Integration & UI Enhancements**

* Integrated backend chat history API into the frontend (`api/chat/history/route.ts`), enabling history fetch and reset from the UI.
* Updated the chat page to load chat history on mount, restore input drafts, auto-scroll to the latest message, and provide a "Reset" button to clear history and input. Improved layout for better usability. [[1]](diffhunk://#diff-068a28fe2e9c79c0596ac9b6a8ab0856e5105337373bb6f272531195e1d6dd8fL6-R72) [[2]](diffhunk://#diff-068a28fe2e9c79c0596ac9b6a8ab0856e5105337373bb6f272531195e1d6dd8fL41-R88) [[3]](diffhunk://#diff-068a28fe2e9c79c0596ac9b6a8ab0856e5105337373bb6f272531195e1d6dd8fL69-R140) [[4]](diffhunk://#diff-068a28fe2e9c79c0596ac9b6a8ab0856e5105337373bb6f272531195e1d6dd8fR193-L142)